### PR TITLE
FIX: Broken Dependency in aufs2-util.spec

### DIFF
--- a/aufs2-util.spec
+++ b/aufs2-util.spec
@@ -13,8 +13,6 @@ BuildRequires: glibc-static
 BuildRequires: coreutils
 BuildRequires: sed
 BuildRequires: binutils
-BuildRequires: kernel-aufs21-headers
-#Requires: kernel-aufs21
 
 %description
 User space utilities for aufs2 kernel module (union file system).
@@ -49,6 +47,8 @@ rm -rf $RPM_BUILD_ROOT
 /usr/share/man/man5/aufs.5.gz
 
 %changelog
+* Fri Apr 24 2015 Rene Meusel <rene.meusel@cern.ch>
+- Remove kernel-aufs21-headers dependency
 * Wed Jun 19 2013 Jakob Blomer <jblomer@cern.ch>
 - Remove kernel-aufs21 dependency
 * Fri Nov 09 2012 Jakob Blomer <jblomer@cern.ch>


### PR DESCRIPTION
This removes the build dependency of `kernel-aufs21-headers` which is obsolete. Unfortunately, now the build dependency on `aufs_type.h` is not reflected in the spec file anymore. See [CVM-826](https://sft.its.cern.ch/jira/browse/CVM-826).
